### PR TITLE
Fixed problems processing Mulit-Echo images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 #flywheel/fmriprep
 
-FROM python:3.7
+#FROM python:3.7
+FROM python:3.10
 MAINTAINER Tinashe Tapera <taperat@pennmedicine.upenn.edu>
 
 # Make directory for flywheel spec (v0)
@@ -13,14 +14,15 @@ ENTRYPOINT ["/flywheel/v0/fw_heudiconv_run.py"]
 
 # Copy over python scripts that generate the BIDS hierarchy
 RUN apt-get -y update && apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
+#RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - &&\
+RUN curl -fsSL https://deb.nodesource.com/setup_21.x | bash - &&\
     apt-get -y install nodejs &&\
     ln -s /usr/bin/nodejs /usr/local/bin/node
 RUN curl -L https://www.npmjs.com/install.sh | sh
 RUN npm install -g bids-validator
 RUN python3 -m pip install --upgrade pip
 RUN pip install --no-cache nipype pathvalidate
-RUN pip install --no-cache flywheel-sdk~=14.6.5
+RUN pip install --no-cache flywheel-sdk
 
 COPY . /src
 

--- a/docs/source/environment.yml
+++ b/docs/source/environment.yml
@@ -15,7 +15,6 @@ dependencies:
 - sphinx_rtd_theme
 - mock
 - future
-- nibabel
 - statsmodels
 - xvfbwrapper
 - configparser

--- a/fw_heudiconv/backend_funcs/query.py
+++ b/fw_heudiconv/backend_funcs/query.py
@@ -4,7 +4,6 @@ import os
 import warnings
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning)
-    from nibabel.nicom.dicomwrappers import wrapper_from_data
 
 
 CONVERTABLE_TYPES = ("bvec", "bval", "nifti")
@@ -63,15 +62,30 @@ def acquisition_to_heudiconv(client, acq, context):
         zip_info = None
         dcm_info = {}
     # Make it a nicom wrapper to handle all sorts of different dicom styles
-    mw = wrapper_from_data(dcm_info)
+    #mw = wrapper_from_data(dcm_info)
+    #log.info("mw.image_shape = '{}'".format(mw.image_shape))
     num_dicoms = len(zip_info.members) if zip_info else -1
-    image_shape = mw.image_shape
-    if image_shape is None:
-        image_shape = (-1, -1, -1, -1)
-    else:
-        image_shape = mw.image_shape + (num_dicoms,)
-        while len(image_shape) < 4:
-            image_shape = image_shape + (-1,)
+    #image_shape = mw.image_shape
+    #if image_shape is None:
+    #    image_shape = (-1, -1, -1, -1)
+    #else:
+        #image_shape = mw.image_shape + (num_dicoms,)
+    #    while len(image_shape) < 4:
+    #        image_shape = image_shape + (-1,)
+
+    Rows = -1
+    if "Rows" in dcm_info:
+        Rows = dcm_info["Rows"]
+
+    Columns = -1 
+    if ("Columns" in dcm_info):
+        Columns = dcm_info["Columns"]
+
+    image_shape = (-1, -1, -1, -1)
+    if (Rows > 0 and Columns > 0):
+       image_shape = (Rows, Columns, num_dicoms, -1)
+
+    log.info("{}: Image Shape = '{}', num_dicoms = '{}'".format(acq.label,image_shape,num_dicoms))
 
     for fileobj in acq.files:
         log.debug('filename: %s', fileobj.name)
@@ -80,7 +94,7 @@ def acquisition_to_heudiconv(client, acq, context):
         info = fileobj.info
 
         # Make it a nicom wrapper to handle all sorts of different dicom styles
-        mw = wrapper_from_data(info)
+        #mw = wrapper_from_data(info)
 
         log.debug('uid: %s', info.get("SeriesInstanceUID"))
         to_convert.append(SeqInfo(

--- a/fw_heudiconv_run.py
+++ b/fw_heudiconv_run.py
@@ -15,6 +15,9 @@ logger.info("{:=^70}\n".format(": fw-heudiconv gear manager starting up :"))
 
 # start up inputs
 invocation = json.loads(open('config.json').read())
+
+logger.info(json.dumps(invoication, indent=2))
+
 config = invocation['config']
 inputs = invocation['inputs']
 destination = invocation['destination']

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-    "name": "fw-heudiconv",
-    "label": "Flywheel HeuDiConv",
+    "name": "dev-fw-heudiconv",
+    "label": "Dev Flywheel HeuDiConv",
     "description": "HeuDiConv-style BIDS curation on Flywheel. Flywheel HeuDiConv (or fw-heudiconv, pronounced /fwu\u02d0 di k\u0251\u02d0 n(v)/) is a Python-based toolkit that leverages the flexibility and comprehensiveness of HeuDiConv to curate neuroimaging data on Flywheel into a BIDS-valid format.",
-    "version": "0.2.15_1.0.1",
+    "version": "0.2.15_1.0.1-dev-001",
     "inputs": {
         "api_key": {
             "base": "api-key"
@@ -43,7 +43,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "pennbbl/fw-heudiconv:0.2.15_1.0.1"
+            "image": "pennbbl/fw-heudiconv:0.2.15_1.0.1-dev-001"
         },
         "flywheel": {
             "suite": "PennBBL"

--- a/manifest.json
+++ b/manifest.json
@@ -1,43 +1,63 @@
 {
-	"name": "fw-heudiconv",
-	"label": "Flywheel HeuDiConv",
-	"description": "HeuDiConv-style BIDS curation on Flywheel. Flywheel HeuDiConv (or fw-heudiconv, pronounced /fwuː di kɑː n(v)/) is a Python-based toolkit that leverages the flexibility and comprehensiveness of HeuDiConv to curate neuroimaging data on Flywheel into a BIDS-valid format.",
-	"version": "0.2.15_0.4.3",
-	"inputs": {
-		"api_key": {
-			"base": "api-key"
-		},
-		"heuristic": {
-			"base": "file",
-			"description": "Python file implementing a heudiconv heuristic",
-			"optional": true
-		}
-	},
-	"config": {
-		"action": {
-			"default": "Curate",
-			"description": "Curate: Apply heuristic to project. Export: Create zip of BIDS tree. Tabulate: Create a table of sequence information in a project. Clear: Clear BIDS data from project. Reproin Check: Apply the reproin heuristic to a list of reproin names to check for validity. Meta: Autogenerate BIDS metadata for project.",
-			"type": "string",
-			"enum": ["Curate", "Export", "Tabulate", "Clear", "Reproin", "Validate"]
-		},
-		"dry_run": {
-			"default": true,
-			"description": "Run without applying changes",
-			"type": "boolean"
-		}
-	},
-	"command": "./fw_heudiconv_run.py",
-	"author": "Tinashe Michael Tapera",
-	"maintainer": "Tinashe Michael Tapera",
-	"cite": "",
-	"license": "Other",
-	"source": "",
-	"url": "https://github.com/PennBBL/fw-heudiconv",
-	"custom": {
-		"gear-builder": {
-			"category": "analysis",
-			"image": "pennbbl/fw-heudiconv:0.2.15_0.4.3"
-		},
-		"flywheel":{"suite": "PennBBL"}
-	}
+    "name": "fw-heudiconv",
+    "label": "Flywheel HeuDiConv",
+    "description": "HeuDiConv-style BIDS curation on Flywheel. Flywheel HeuDiConv (or fw-heudiconv, pronounced /fwu\u02d0 di k\u0251\u02d0 n(v)/) is a Python-based toolkit that leverages the flexibility and comprehensiveness of HeuDiConv to curate neuroimaging data on Flywheel into a BIDS-valid format.",
+    "version": "0.2.15_1.0.1",
+    "inputs": {
+        "api_key": {
+            "base": "api-key"
+        },
+        "heuristic": {
+            "base": "file",
+            "description": "Python file implementing a heudiconv heuristic",
+            "optional": true
+        }
+    },
+    "config": {
+        "action": {
+            "default": "Curate",
+            "description": "Curate: Apply heuristic to project. Export: Create zip of BIDS tree. Tabulate: Create a table of sequence information in a project. Clear: Clear BIDS data from project. Reproin Check: Apply the reproin heuristic to a list of reproin names to check for validity. Meta: Autogenerate BIDS metadata for project.",
+            "type": "string",
+            "enum": [
+                "Curate",
+                "Export",
+                "Tabulate",
+                "Clear",
+                "Reproin",
+                "Validate"
+            ]
+        },
+        "dry_run": {
+            "default": true,
+            "description": "Run without applying changes",
+            "type": "boolean"
+        }
+    },
+    "command": "./fw_heudiconv_run.py",
+    "author": "Tinashe Michael Tapera",
+    "maintainer": "Tinashe Michael Tapera",
+    "cite": "",
+    "license": "Other",
+    "source": "",
+    "url": "https://github.com/PennBBL/fw-heudiconv",
+    "custom": {
+        "gear-builder": {
+            "category": "analysis",
+            "image": "pennbbl/fw-heudiconv:0.2.15_1.0.1"
+        },
+        "flywheel": {
+            "suite": "PennBBL"
+        }
+    },
+    "environment": {
+        "PATH": "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "LANG": "C.UTF-8",
+        "GPG_KEY": "A035C8C19219BA821ECEA86B64E628F8D684696D",
+        "PYTHON_VERSION": "3.10.14",
+        "PYTHON_PIP_VERSION": "23.0.1",
+        "PYTHON_SETUPTOOLS_VERSION": "65.5.1",
+        "PYTHON_GET_PIP_URL": "https://github.com/pypa/get-pip/raw/dbf0c85f76fb6e1ab42aa672ffca6f0a675d9ee4/public/get-pip.py",
+        "PYTHON_GET_PIP_SHA256": "dfe9fd5c28dc98b5ac17979a953ea550cec37ae1b47a5116007395bfacff2ab9",
+        "FLYWHEEL": "/flywheel/v0"
+    }
 }

--- a/release.sh
+++ b/release.sh
@@ -29,11 +29,11 @@ fi
 echo Uploading to pip...
 
 python setup.py sdist
-<<<<<<< HEAD
+#<<<<<<< HEAD
 twine upload dist/* --skip-existing
-=======
-twine upload --skip-existing dist/*
->>>>>>> 451d0170cd190ca6cceb86def6dc51bc45a73802
+#=======
+#twine upload --skip-existing dist/*
+#>>>>>>> 451d0170cd190ca6cceb86def6dc51bc45a73802
 
 echo Uploading gear...
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flywheel-sdk ~= 14.6.5
+flywheel-sdk
 pandas
 bids-validator
 validators
@@ -6,6 +6,5 @@ sphinx-argparse
 commonmark
 pathvalidate
 pytest
-nibabel
 pytest-cov
 heudiconv

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,8 @@ classifiers =
 
 [options]
 install_requires =
-    flywheel-sdk ~= 14.6.5
+    flywheel-sdk ~= 18.1.1
     bids-validator
-    nibabel >=3.0.0
     indexed_gzip >=0.8.8
     nilearn !=0.5.0, !=0.5.1
     nipype >=1.3.1
@@ -47,7 +46,6 @@ install_requires =
     scikit-learn >=0.20.2
     scikit-image
     statsmodels
-    nibabel
     heudiconv
 test_requires =
     coverage

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,13 @@ setuptools.setup(
     url="https://github.com/PennBBL/fw_heudiconv",
     packages=setuptools.find_packages(),
     install_requires=[
-        "flywheel-sdk~=14.6.5",
+        "flywheel-sdk~=18.1.1",
         "pandas",
         "bids-validator",
         "validators",
         "pathvalidate",
         "pytest",
         "pytest-cov",
-        "nibabel",
         "heudiconv"
     ],
     classifiers=[


### PR DESCRIPTION
Seimann's software now (2/1/2024) produces Multi-Echo images.  The flywheel representation for these images are not compatible with nibabel.

It seems that nibabel was only being used to get the number of rows and columns in the images.  Removed dependency on nibabel and now get the row and column numbers directly from the flywheel image metadata.

-Gaylord